### PR TITLE
Reload config upon sighup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ clap = "2.33"
 simple_logger = "1.11"
 log = "0.4"
 ed25519-zebra = "2"
+async-std = { version = "1.8.0", features = ["std"] }
 
 [build-dependencies]
 tonic-build = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/signer/server.rs"
 config = { version = "0.10", features = ["json"] }
 tonic = { version = "0.3", features = ["transport", "tls"] }
 prost = "0.6"
-tokio = { version = "0.2", features = ["macros", "fs"] }
+tokio = { version = "0.2", features = ["macros", "fs", "signal"] }
 serde = { version = "1.0", features = ["derive"] }
 hex = "0.4"
 itertools = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,6 @@ simple_logger = "1.11"
 log = "0.4"
 ed25519-zebra = "2"
 async-std = { version = "1.8.0", features = ["std"] }
-anyhow = "1.0.38"
-custom_error = "1.8.0"
 thiserror = "1.0.23"
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,12 +26,15 @@ tokio = { version = "0.2", features = ["macros", "fs", "signal"] }
 serde = { version = "1.0", features = ["derive"] }
 hex = "0.4"
 itertools = "0.9"
-futures = "0.3"
+futures = "0.3.12"
 clap = "2.33"
 simple_logger = "1.11"
 log = "0.4"
 ed25519-zebra = "2"
 async-std = { version = "1.8.0", features = ["std"] }
+anyhow = "1.0.38"
+custom_error = "1.8.0"
+thiserror = "1.0.23"
 
 [build-dependencies]
 tonic-build = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,13 +26,13 @@ tokio = { version = "0.2", features = ["macros", "fs", "signal"] }
 serde = { version = "1.0", features = ["derive"] }
 hex = "0.4"
 itertools = "0.9"
-futures = "0.3.12"
+futures = "0.3"
 clap = "2.33"
 simple_logger = "1.11"
 log = "0.4"
 ed25519-zebra = "2"
-async-std = { version = "1.8.0", features = ["std"] }
-thiserror = "1.0.23"
+async-std = { version = "1.8", features = ["std"] }
+thiserror = "1.0"
 
 [build-dependencies]
 tonic-build = "0.3"

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -7,7 +7,7 @@ use ed25519_zebra::{VerificationKey, VerificationKeyBytes, SigningKey};
 pub struct DispatcherConfig {
     pub bind_addr: String,
     pub signers: Vec<HexKeySigner>,
-    pub tlsauth: ClientTlsAuth
+    pub tlsauth: ClientTlsAuth,
 }
 
 #[derive(Deserialize, Clone, Debug)]
@@ -52,7 +52,7 @@ impl TryInto<Vec<u8>> for HexEd25519Key {
         Vec::from_hex(self.0)
     }
 }
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct BytesKeySigner {
     pub pubkey: Vec<u8>,
     pub endpoint: String

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -50,7 +50,6 @@ pub struct BytesPubPriv {
     pub privkey: Vec<u8>
 }
 
-
 fn validate_ed25519_pubkey(pubkey: &HexEd25519Key) -> bool {
     let pubkey_bytes: Vec<u8> = match pubkey.to_owned().try_into() {
         Ok(bytes) => bytes,

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -77,7 +77,7 @@ fn validate_ed25519_privkey(keypair: &HexPubPriv) -> bool {
             };
             let pubkey_computed = VerificationKeyBytes::from(&privkey_provided);
             pubkey_provided_bytes == pubkey_computed.as_ref()
-        }
+        },
         _ => false,
     }
 }

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -7,28 +7,12 @@ use ed25519_zebra::{VerificationKey, VerificationKeyBytes, SigningKey};
 pub struct DispatcherConfig {
     pub bind_addr: String,
     pub signers: Vec<HexKeySigner>,
-    pub tlsauth: ClientTlsAuth,
-}
-
-#[derive(Deserialize, Clone, Debug)]
-pub struct ClientTlsAuth {
-    pub ca: String,
-    pub client_cert: String,
-    pub client_key: String
 }
 
 #[derive(Deserialize, Clone, Debug)]
 pub struct SignerConfig {
     pub bind_addr: String,
     pub keys: Vec<HexPubPriv>,
-    pub tls: ServerTlsAuth
-}
-
-#[derive(Deserialize, Clone, Debug)]
-pub struct ServerTlsAuth {
-    pub ca: String,
-    pub cert: String,
-    pub key: String
 }
 
 #[derive(Deserialize, Clone, Debug)]

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -43,7 +43,7 @@ pub struct BytesKeySigner {
     pub endpoint: String,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct BytesPubPriv {
     pub pubkey: Vec<u8>,
     pub privkey: Vec<u8>,

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -1,9 +1,8 @@
-use serde::Deserialize;
-use hex::FromHex;
-use std::convert::{TryFrom, TryInto};
-use ed25519_zebra::{VerificationKey, VerificationKeyBytes, SigningKey};
 use crate::RemoteSignerError;
-
+use ed25519_zebra::{SigningKey, VerificationKey, VerificationKeyBytes};
+use hex::FromHex;
+use serde::Deserialize;
+use std::convert::{TryFrom, TryInto};
 
 #[derive(Deserialize, Clone, Debug)]
 pub struct DispatcherConfig {
@@ -20,13 +19,13 @@ pub struct SignerConfig {
 #[derive(Deserialize, Clone, Debug)]
 pub struct HexKeySigner {
     pub pubkey: HexEd25519Key,
-    pub endpoint: String
+    pub endpoint: String,
 }
 
 #[derive(Deserialize, Clone, Debug)]
 pub struct HexPubPriv {
     pub pubkey: HexEd25519Key,
-    pub privkey: HexEd25519Key
+    pub privkey: HexEd25519Key,
 }
 
 #[derive(Deserialize, Clone, Debug)]
@@ -41,23 +40,23 @@ impl TryInto<Vec<u8>> for HexEd25519Key {
 #[derive(Debug, Clone)]
 pub struct BytesKeySigner {
     pub pubkey: Vec<u8>,
-    pub endpoint: String
+    pub endpoint: String,
 }
 
 #[derive(Debug)]
 pub struct BytesPubPriv {
     pub pubkey: Vec<u8>,
-    pub privkey: Vec<u8>
+    pub privkey: Vec<u8>,
 }
 
 fn validate_ed25519_pubkey(pubkey: &HexEd25519Key) -> bool {
     let pubkey_bytes: Vec<u8> = match pubkey.to_owned().try_into() {
         Ok(bytes) => bytes,
-        _ => return false
+        _ => return false,
     };
     match VerificationKey::try_from(pubkey_bytes.as_slice()) {
         Ok(_) => true,
-        _ => false
+        _ => false,
     }
 }
 
@@ -66,25 +65,27 @@ fn validate_ed25519_pubkeys(pubkeys: Vec<&HexEd25519Key>) -> bool {
 }
 
 fn validate_ed25519_privkey(keypair: &HexPubPriv) -> bool {
-        let privkey_provided_bytes: Vec<u8> = match keypair.privkey.to_owned().try_into() {
-            Ok(bytes) => bytes,
-            _ => return false
-        };
-        match SigningKey::try_from(privkey_provided_bytes.as_slice()) {
-            Ok(privkey_provided) => {
-                let pubkey_provided_bytes: Vec<u8> = match keypair.pubkey.to_owned().try_into() {
-                    Ok(bytes) => bytes,
-                    _ => return false
-                };
-                let pubkey_computed = VerificationKeyBytes::from(&privkey_provided);
-                pubkey_provided_bytes == pubkey_computed.as_ref()
-            },
-            _ => false
+    let privkey_provided_bytes: Vec<u8> = match keypair.privkey.to_owned().try_into() {
+        Ok(bytes) => bytes,
+        _ => return false,
+    };
+    match SigningKey::try_from(privkey_provided_bytes.as_slice()) {
+        Ok(privkey_provided) => {
+            let pubkey_provided_bytes: Vec<u8> = match keypair.pubkey.to_owned().try_into() {
+                Ok(bytes) => bytes,
+                _ => return false,
+            };
+            let pubkey_computed = VerificationKeyBytes::from(&privkey_provided);
+            pubkey_provided_bytes == pubkey_computed.as_ref()
         }
+        _ => false,
+    }
 }
 
 fn validate_ed25519_privkeys(keypairs: &Vec<HexPubPriv>) -> bool {
-    keypairs.iter().all(|keypair| validate_ed25519_privkey(keypair))
+    keypairs
+        .iter()
+        .all(|keypair| validate_ed25519_privkey(keypair))
 }
 
 pub fn parse_dispatcher(path: &str) -> crate::Result<(DispatcherConfig, Vec<BytesKeySigner>)> {
@@ -92,16 +93,20 @@ pub fn parse_dispatcher(path: &str) -> crate::Result<(DispatcherConfig, Vec<Byte
     let mut conf = config::Config::default();
     conf.merge(conf_file)?;
     let conf = conf.try_into::<DispatcherConfig>()?;
-    let pubkeys = conf.signers.iter().map(|signer| &signer.pubkey ).collect();
+    let pubkeys = conf.signers.iter().map(|signer| &signer.pubkey).collect();
     if !validate_ed25519_pubkeys(pubkeys) {
-        return Err(RemoteSignerError::Config(config::ConfigError::Message(String::from("At least one of the configured HexEd25519 public keys is invalid."))));
+        return Err(RemoteSignerError::Config(config::ConfigError::Message(
+            String::from("At least one of the configured HexEd25519 public keys is invalid."),
+        )));
     }
-    let keysigners: Vec<BytesKeySigner> = conf.signers.iter().map(|signer|
-        BytesKeySigner {
+    let keysigners: Vec<BytesKeySigner> = conf
+        .signers
+        .iter()
+        .map(|signer| BytesKeySigner {
             pubkey: signer.pubkey.to_owned().try_into().unwrap(),
-            endpoint: signer.endpoint.to_owned()
-        }
-    ).collect();
+            endpoint: signer.endpoint.to_owned(),
+        })
+        .collect();
     Ok((conf, keysigners))
 }
 
@@ -110,18 +115,22 @@ pub fn parse_signer(path: &str) -> crate::Result<(SignerConfig, Vec<BytesPubPriv
     let mut conf = config::Config::default();
     conf.merge(conf_file)?;
     let conf = conf.try_into::<SignerConfig>()?;
-    let pubkeys = conf.keys.iter().map(|keypair| &keypair.pubkey ).collect();
+    let pubkeys = conf.keys.iter().map(|keypair| &keypair.pubkey).collect();
     if !validate_ed25519_pubkeys(pubkeys) {
-        return Err(RemoteSignerError::Config(config::ConfigError::Message(String::from("At least one of the configured HexEd25519 public keys is invalid."))));
+        return Err(RemoteSignerError::Config(config::ConfigError::Message(
+            String::from("At least one of the configured HexEd25519 public keys is invalid."),
+        )));
     }
     if !validate_ed25519_privkeys(&conf.keys) {
         return Err(RemoteSignerError::Config(config::ConfigError::Message(String::from("At least one of the configured HexEd25519 private keys is invalid or does not match the corresponding public key."))));
     }
-    let keypairs: Vec<BytesPubPriv> = conf.keys.iter().map(|keypair|
-        BytesPubPriv {
+    let keypairs: Vec<BytesPubPriv> = conf
+        .keys
+        .iter()
+        .map(|keypair| BytesPubPriv {
             pubkey: keypair.pubkey.to_owned().try_into().unwrap(),
-            privkey: keypair.privkey.to_owned().try_into().unwrap()
-        }
-    ).collect();
+            privkey: keypair.privkey.to_owned().try_into().unwrap(),
+        })
+        .collect();
     Ok((conf, keypairs))
 }

--- a/src/dispatcher/client.rs
+++ b/src/dispatcher/client.rs
@@ -9,11 +9,12 @@ pub mod dispatcher {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut client = SignatureDispatcherClient::connect("http://localhost:50051").await?;
+    let mut client = SignatureDispatcherClient::connect("http://dispatcher.remote-signer:50051").await?;
 
     let request = tonic::Request::new(SignMilestoneRequest {
         pub_keys: vec![
-            Vec::from_hex("839d0a84fc988ebadfb641e7b434ccb719cbaf584b6f60451ac3b4b362975ea9").unwrap()
+            Vec::from_hex("d578d0a8e5392040cf5c3ba0153c28c300d8eaed3d8d7ef43729cadfe1e2467b").unwrap(),
+            Vec::from_hex("268783e7277c7c9f6dc898d08f5ca458941de2eb339e7da948239cc3647dffcc").unwrap()
         ],
         ms_essence: "Sign this!".as_bytes().to_vec()
     });

--- a/src/dispatcher/client.rs
+++ b/src/dispatcher/client.rs
@@ -9,14 +9,14 @@ pub mod dispatcher {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut client = SignatureDispatcherClient::connect("http://localhost:50051").await?;
+    let mut client = SignatureDispatcherClient::connect("http://dispatcher.remote-signer:50051").await?;
 
     let request = tonic::Request::new(SignMilestoneRequest {
-        pub_keys: vec![Vec::from_hex(
-            "839d0a84fc988ebadfb641e7b434ccb719cbaf584b6f60451ac3b4b362975ea9",
-        )
-        .unwrap()],
-        ms_essence: "Sign this!".as_bytes().to_vec(),
+        pub_keys: vec![
+            Vec::from_hex("d578d0a8e5392040cf5c3ba0153c28c300d8eaed3d8d7ef43729cadfe1e2467b").unwrap(),
+            Vec::from_hex("268783e7277c7c9f6dc898d08f5ca458941de2eb339e7da948239cc3647dffcc").unwrap()
+        ],
+        ms_essence: "Sign this!".as_bytes().to_vec()
     });
 
     let response = client.sign_milestone(request).await?;

--- a/src/dispatcher/client.rs
+++ b/src/dispatcher/client.rs
@@ -9,12 +9,11 @@ pub mod dispatcher {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut client = SignatureDispatcherClient::connect("http://dispatcher.remote-signer:50051").await?;
+    let mut client = SignatureDispatcherClient::connect("http://localhost:50051").await?;
 
     let request = tonic::Request::new(SignMilestoneRequest {
         pub_keys: vec![
-            Vec::from_hex("d578d0a8e5392040cf5c3ba0153c28c300d8eaed3d8d7ef43729cadfe1e2467b").unwrap(),
-            Vec::from_hex("268783e7277c7c9f6dc898d08f5ca458941de2eb339e7da948239cc3647dffcc").unwrap()
+            Vec::from_hex("3a0f0d32ed6e427c581da7ac52d22e727bee48c4af74a1850a57a2047c1e387e").unwrap()
         ],
         ms_essence: "Sign this!".as_bytes().to_vec()
     });

--- a/src/dispatcher/client.rs
+++ b/src/dispatcher/client.rs
@@ -9,18 +9,18 @@ pub mod dispatcher {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut client = SignatureDispatcherClient::connect("http://dispatcher.remote-signer:50051").await?;
+    let mut client = SignatureDispatcherClient::connect("http://localhost:50051").await?;
 
     let request = tonic::Request::new(SignMilestoneRequest {
-        pub_keys: vec![
-            Vec::from_hex("d578d0a8e5392040cf5c3ba0153c28c300d8eaed3d8d7ef43729cadfe1e2467b").unwrap(),
-            Vec::from_hex("268783e7277c7c9f6dc898d08f5ca458941de2eb339e7da948239cc3647dffcc").unwrap()
-        ],
-        ms_essence: "Sign this!".as_bytes().to_vec()
+        pub_keys: vec![Vec::from_hex(
+            "839d0a84fc988ebadfb641e7b434ccb719cbaf584b6f60451ac3b4b362975ea9",
+        )
+        .unwrap()],
+        ms_essence: "Sign this!".as_bytes().to_vec(),
     });
-    
+
     let response = client.sign_milestone(request).await?;
-    
+
     println!("RESPONSE={:?}", response);
 
     Ok(())

--- a/src/dispatcher/client.rs
+++ b/src/dispatcher/client.rs
@@ -13,7 +13,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let request = tonic::Request::new(SignMilestoneRequest {
         pub_keys: vec![
-            Vec::from_hex("3a0f0d32ed6e427c581da7ac52d22e727bee48c4af74a1850a57a2047c1e387e").unwrap()
+            Vec::from_hex("839d0a84fc988ebadfb641e7b434ccb719cbaf584b6f60451ac3b4b362975ea9").unwrap()
         ],
         ms_essence: "Sign this!".as_bytes().to_vec()
     });

--- a/src/dispatcher/server.rs
+++ b/src/dispatcher/server.rs
@@ -191,6 +191,7 @@ async fn reload_configs_upon_signal(
     // Print whenever a HUP signal is received
     loop {
         stream.recv().await;
+        info!("sighup received");
         let conf = parse_confs(conf_path);
         if conf.is_err() {
             error!("Can't parse configs. {:?}", conf.err().unwrap());

--- a/src/dispatcher/server.rs
+++ b/src/dispatcher/server.rs
@@ -162,7 +162,7 @@ async fn main() -> remote_signer::Result<()> {
     info!("Start");
 
     let conf_path = config_arg.value_of("config").unwrap();
-    let (addr, dispatcher) = create_dispatcher(conf_path).await?;
+    let (addr, dispatcher) = create_dispatcher(conf_path)?;
     debug!("Initialized Dispatcher server: {:?}", dispatcher);
 
     let key_signers = Arc::clone(&dispatcher.keysigners);
@@ -188,15 +188,15 @@ async fn main() -> remote_signer::Result<()> {
     }
 }
 
-async fn create_dispatcher(conf_path: &str) -> remote_signer::Result<(SocketAddr, Ed25519SignatureDispatcher)> {
-    let (_, keysigners, addr) = parse_confs(conf_path).await?;
+fn create_dispatcher(conf_path: &str) -> remote_signer::Result<(SocketAddr, Ed25519SignatureDispatcher)> {
+    let (_, keysigners, addr) = parse_confs(conf_path)?;
     let dispatcher = Ed25519SignatureDispatcher {
         keysigners: Arc::new(Mutex::new(keysigners))
     };
     Ok((addr, dispatcher))
 }
 
-async fn parse_confs(conf_path: &str) -> remote_signer::Result<(DispatcherConfig, Vec<BytesKeySigner>, SocketAddr)> {
+fn parse_confs(conf_path: &str) -> remote_signer::Result<(DispatcherConfig, Vec<BytesKeySigner>, SocketAddr)> {
     info!("Parsing configuration file `{}`.", conf_path);
     let (config, keysigners) = config::parse_dispatcher(conf_path)?;
     let addr = config.bind_addr.parse()?;
@@ -210,7 +210,7 @@ async fn reload_configs_upon_signal(conf_path : &str, key_signers_a: Arc<Mutex<V
     // Print whenever a HUP signal is received
     loop {
         stream.recv().await;
-        let conf = parse_confs(conf_path).await;
+        let conf = parse_confs(conf_path);
         if conf.is_err() {
             error!("Can't parse configs. {:?}", conf.err().unwrap());
             continue;

--- a/src/dispatcher/server.rs
+++ b/src/dispatcher/server.rs
@@ -12,8 +12,8 @@ use futures::{future, TryFutureExt};
 use itertools::Itertools;
 use simple_logger::SimpleLogger;
 use tokio::signal::unix::{signal, SignalKind};
-use tonic::transport::Channel;
-use tonic::{transport::Server, Request, Response, Status};
+use tonic::transport::{Channel, Server};
+use tonic::{Request, Response, Status};
 
 use dispatcher::signature_dispatcher_server::{SignatureDispatcher, SignatureDispatcherServer};
 use dispatcher::{SignMilestoneRequest, SignMilestoneResponse};

--- a/src/dispatcher/server.rs
+++ b/src/dispatcher/server.rs
@@ -191,7 +191,6 @@ async fn reload_configs_upon_signal(
     // Print whenever a HUP signal is received
     loop {
         stream.recv().await;
-        info!("sighup received");
         let conf = parse_confs(conf_path);
         if conf.is_err() {
             error!("Can't parse configs. {:?}", conf.err().unwrap());

--- a/src/dispatcher/server.rs
+++ b/src/dispatcher/server.rs
@@ -200,7 +200,7 @@ async fn reload_configs_upon_signal(
         let mut signers = key_signers_a.lock().await;
         signers.clear();
         signers.extend_from_slice(&keysigners);
-        info!("Configuration reloaded upon sighup")
+        info!("Configuration reloaded upon sighup");
     }
 }
 

--- a/src/dispatcher/server.rs
+++ b/src/dispatcher/server.rs
@@ -56,7 +56,7 @@ impl SignatureDispatcher for Ed25519SignatureDispatcher {
         // We do not need to check for the lexicographical sorting of the keys, it is not our job
 
         let keysigners_guard = self.keysigners.lock().await;
-        let mut matched_signers = pub_keys_unique.map(|pubkey| {
+        let matched_signers = pub_keys_unique.map(|pubkey| {
             keysigners_guard
                 .iter()
                 .find(|keysigner| keysigner.pubkey == *pubkey)

--- a/src/dispatcher/server.rs
+++ b/src/dispatcher/server.rs
@@ -239,8 +239,6 @@ async fn reload_configs_upon_signal(
         let (_, keysigners, _) = conf.unwrap();
         let mut signers = key_signers_a.lock().await;
         signers.clear();
-        for signer in keysigners {
-            signers.push(signer);
-        }
+        signers.extend_from_slice(&keysigners);
     }
 }

--- a/src/dispatcher/server.rs
+++ b/src/dispatcher/server.rs
@@ -174,12 +174,9 @@ async fn main() -> remote_signer::Result<()> {
         .serve(addr)
         .map_err(|err| RemoteSignerError::from(err));
 
-    info!("Serving on {}...", addr);
-
     let signal = reload_configs_upon_signal(&conf_path, key_signers);
 
-    info!("listening for sighup");
-
+    info!("Serving on {}...", addr);
     let result = future::try_join(serv, signal).await;
 
     match result {
@@ -204,6 +201,7 @@ fn parse_confs(conf_path: &str) -> remote_signer::Result<(DispatcherConfig, Vec<
 }
 
 async fn reload_configs_upon_signal(conf_path : &str, key_signers_a: Arc<Mutex<Vec<BytesKeySigner>>>) -> remote_signer::Result<()> {
+    info!("listening for sighup");
     let mut stream = signal(SignalKind::hangup())
         .expect("Problems receiving signal");
 

--- a/src/dispatcher/server.rs
+++ b/src/dispatcher/server.rs
@@ -201,6 +201,7 @@ async fn reload_configs_upon_signal(
         let mut signers = key_signers_a.lock().await;
         signers.clear();
         signers.extend_from_slice(&keysigners);
+        info!("Configuration reloaded upon sighup")
     }
 }
 

--- a/src/dispatcher/server.rs
+++ b/src/dispatcher/server.rs
@@ -177,7 +177,7 @@ fn parse_confs(
 ) -> remote_signer::Result<(DispatcherConfig, Vec<BytesKeySigner>, SocketAddr)> {
     info!("Parsing configuration file `{}`.", conf_path);
     let (config, keysigners) = config::parse_dispatcher(conf_path)?;
-    let addr = config.bind_addr.parse()?;
+    let addr = config.bind_addr.parse::<SocketAddr>()?;
     Ok((config, keysigners, addr))
 }
 

--- a/src/dispatcher/server.rs
+++ b/src/dispatcher/server.rs
@@ -1,24 +1,30 @@
-use tonic::{transport::Server, Request, Response, Status};
+#[macro_use] extern crate log;
+
+use std::borrow::{BorrowMut, Borrow};
+use std::convert::TryFrom;
+use std::error::Error;
+use std::net::SocketAddr;
+use std::ops::{DerefMut, Deref};
+use std::rc::Rc;
+use std::sync::{Arc, Mutex};
+
+use clap::{App, Arg, ArgMatches};
+use ed25519_zebra::{Signature, VerificationKey};
+use futures::future;
+use futures::join;
+use itertools::Itertools;
+use log::LevelFilter;
+use simple_logger::SimpleLogger;
+use tokio::signal::unix::{signal, SignalKind};
+use tonic::{Request, Response, Status, transport::Server};
 use tonic::transport::{Certificate, Channel, ClientTlsConfig, Identity};
 
-use dispatcher::signature_dispatcher_server::{SignatureDispatcher, SignatureDispatcherServer};
 use dispatcher::{SignMilestoneRequest, SignMilestoneResponse};
-
+use dispatcher::signature_dispatcher_server::{SignatureDispatcher, SignatureDispatcherServer};
+use remote_signer::common::config;
+use remote_signer::common::config::{BytesKeySigner, DispatcherConfig};
 use signer::signer_client::SignerClient;
 use signer::SignWithKeyRequest;
-
-use remote_signer::common::config;
-
-use clap::{App, Arg};
-use futures::future;
-use itertools::Itertools;
-use std::error::Error;
-use std::convert::TryFrom;
-
-use ed25519_zebra::{Signature, VerificationKey};
-
-use simple_logger::SimpleLogger;
-#[macro_use] extern crate log;
 
 pub mod dispatcher {
     tonic::include_proto!("dispatcher");
@@ -30,9 +36,10 @@ pub mod signer {
 
 #[derive(Debug)]
 pub struct Ed25519SignatureDispatcher {
-    config: config::DispatcherConfig,
-    tls_auth: ClientTlsConfig,
-    keysigners: Vec<config::BytesKeySigner>
+    config: Arc<Mutex<DispatcherConfig>>,
+    tls_auth: Arc<Mutex<ClientTlsConfig>>,
+    keysigners: Arc<Mutex<Vec<config::BytesKeySigner>>>,
+    config_path: Arc<String>
 }
 
 impl Ed25519SignatureDispatcher {
@@ -40,11 +47,27 @@ impl Ed25519SignatureDispatcher {
     {
         Ok(
             Channel::from_shared(endpoint)?
-                .tls_config(self.tls_auth.clone())?
+                // .tls_config(self.tls_auth.clone())?
                 .connect()
                 .await?
         )
     }
+
+    // fn set_config(&mut self, config: DispatcherConfig) {
+    //     self.config = config;
+    // }
+    //
+    // fn set_tls_auth(&mut self, tls_auth: ClientTlsConfig) {
+    //     self.tls_auth = tls_auth;
+    // }
+    //
+    // fn set_key_signers(&mut self, key_signers: Vec<config::BytesKeySigner>) {
+    //     self.keysigners = key_signers;
+    // }
+    //
+    // fn set_config_path(&mut self, config_path: String) {
+    //     self.config_path = config_path;
+    // }
 }
 
 #[tonic::async_trait]
@@ -58,24 +81,29 @@ impl SignatureDispatcher for Ed25519SignatureDispatcher {
 
         let r = request.get_ref();
         // Check that the pubkeys do not repeat
-        let pub_keys_unique = r.pub_keys.iter().unique();
+        let mut pub_keys_unique = r.pub_keys.iter().unique();
         // We do not need to check for the lexicographical sorting of the keys, it is not our job
 
-        let matched_signers = pub_keys_unique.map(|pubkey| {
-            self.keysigners.iter().find(
-                |keysigner| keysigner.pubkey == *pubkey
-            )
-        });
+        let mut matched_signers: Vec<Option<BytesKeySigner>> = Vec::new();
+        {
+            let mut keysigners_guard = self.keysigners.lock().unwrap();
+            for signer in keysigners_guard.iter() {
+                if pub_keys_unique.any(|key| signer.pubkey.eq(key)) {
+                    matched_signers.push(Some(signer.to_owned()));
+                }
+            }
+        }
+
 
         // Clone the iterator to avoid consuming it for the next map
-        if matched_signers.clone().any(|signer| signer.is_none()) {
+        if matched_signers.is_empty() {
             warn!("Requested public key is not known!");
             warn!("Request: {:?}", request);
             warn!("Available Signers: {:?}", self.keysigners);
             return Err(Status::invalid_argument("I don't know the signer for one or more of the provided public keys."))
         }
 
-        let confirmed_signers = matched_signers.map(|signer| signer.unwrap());
+        let confirmed_signers = matched_signers.iter().map(|signer| signer.as_ref().unwrap());
 
         info!("Got Request that matches signers: {:?}", confirmed_signers);
 
@@ -114,7 +142,7 @@ impl SignatureDispatcher for Ed25519SignatureDispatcher {
                             error!("Invalid signature format returned by Signer!");
                             error!("Signer: {:?}", signer);
                             error!("Error: {:?}", e);
-                            return Err(Status::internal(format!("Invalid signature format returned by signer `{}`, {}", signer.endpoint, e)))
+                            return Err(Status::internal(format!("Invalid signature format returned by signer `{}`, {:?}", signer.endpoint, e)))
                         }
                     };
                     if verification_key.verify(&signature, r.ms_essence.as_slice()).is_err() {
@@ -149,7 +177,7 @@ impl SignatureDispatcher for Ed25519SignatureDispatcher {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    SimpleLogger::from_env().init().unwrap();
+    SimpleLogger::from_env().with_level(LevelFilter::Info).init().unwrap();
     let config_arg = App::new("Remote Signer Dispatcher")
         .arg(Arg::with_name("config")
              .short("c")
@@ -160,7 +188,44 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
              .help("Dispatcher .json configuration file")
         ).get_matches();
 
+    info!("Start");
+
     let conf_path = config_arg.value_of("config").unwrap();
+    let (addr, mut dispatcher) = create_dispatcher(conf_path).await?;
+    debug!("Initialized Dispatcher server: {:?}", dispatcher);
+
+    let conf_path = Arc::clone(&dispatcher.config_path);
+    let mut conf = Arc::clone(&dispatcher.config);
+    let mut key_signers = Arc::clone(&dispatcher.keysigners);
+    let mut tls_auth = Arc::clone(&dispatcher.tls_auth);
+
+
+    let mut server = Server::builder();
+    let serv = server.add_service(SignatureDispatcherServer::new(dispatcher))
+        .serve(addr);
+    info!("Serving on {}...", addr);
+
+    let signal = reload_configs_upon_signal(&conf_path, conf, key_signers, tls_auth);
+
+    info!("listening for sighup");
+
+    futures::join!(serv, signal);
+    Ok(())
+}
+
+async fn create_dispatcher(conf_path: &str) -> Result<(SocketAddr, Ed25519SignatureDispatcher), Box<dyn std::error::Error>> {
+    let (config, keysigners, addr, tls_auth) = parse_confs(conf_path).await?;
+    let config_path = conf_path.to_string();
+    let dispatcher = Ed25519SignatureDispatcher {
+        config: Arc::new(Mutex::new(config)),
+        tls_auth: Arc::new(Mutex::new(tls_auth)),
+        keysigners: Arc::new(Mutex::new(keysigners)),
+        config_path: Arc::new(config_path)
+    };
+    Ok((addr, dispatcher))
+}
+
+async fn parse_confs(conf_path: &str) -> Result<(DispatcherConfig, Vec<BytesKeySigner>, SocketAddr, ClientTlsConfig), Box<dyn std::error::Error>> {
     info!("Parsing configuration file `{}`.", conf_path);
     let (config, keysigners) = config::parse_dispatcher(conf_path)?;
     debug!("Parsed configuration file: {:?}", config);
@@ -173,15 +238,24 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let tls_auth = ClientTlsConfig::new()
         .ca_certificate(server_root_ca_cert)
         .identity(client_identity);
-    let dispatcher = Ed25519SignatureDispatcher { config, tls_auth, keysigners };
-    debug!("Initialized Dispatcher server: {:?}", dispatcher);
+    Ok((config, keysigners, addr, tls_auth))
+}
 
-    info!("Serving on {}...", addr);
+async fn reload_configs_upon_signal(conf_path : &str, mut config_a: Arc<Mutex<DispatcherConfig>>, mut key_signers_a: Arc<Mutex<Vec<BytesKeySigner>>>,
+mut tls_auth_a: Arc<Mutex<ClientTlsConfig>>) -> Result<(), Box<dyn std::error::Error>> {
+    let mut stream = signal(SignalKind::hangup())?;
 
-    Server::builder()
-        .add_service(SignatureDispatcherServer::new(dispatcher))
-        .serve(addr)
-        .await?;
-
-    Ok(())
+    // Print whenever a HUP signal is received
+    loop {
+        stream.recv().await;
+        info!("got signal HUP");
+        let (config, keysigners, _, tls_auth) = parse_confs(conf_path).await?;
+        // config_a.clone_from(&Arc::new(config));
+        let mut signers = key_signers_a.lock().unwrap();
+        signers.clear();
+        for bk in keysigners  {
+            signers.push(bk)
+        }
+        // tls_auth_a.clone_from(&Arc::new(tls_auth));
+    }
 }

--- a/src/dispatcher/server.rs
+++ b/src/dispatcher/server.rs
@@ -57,29 +57,24 @@ impl SignatureDispatcher for Ed25519SignatureDispatcher {
 
         let r = request.get_ref();
         // Check that the pubkeys do not repeat
-        let mut pub_keys_unique = r.pub_keys.iter().unique();
+        let pub_keys_unique = r.pub_keys.iter().unique();
         // We do not need to check for the lexicographical sorting of the keys, it is not our job
 
-        let mut matched_signers: Vec<Option<BytesKeySigner>> = Vec::new();
-        {
-            let keysigners_guard = self.keysigners.lock().await;
-            for signer in keysigners_guard.iter() {
-                if pub_keys_unique.any(|key| signer.pubkey.eq(key)) {
-                    matched_signers.push(Some(signer.to_owned()));
-                }
-            }
-        }
+        let keysigners_guard = self.keysigners.lock().await;
+        let mut matched_signers = pub_keys_unique.map(|pubkey| {
+            keysigners_guard.iter().find(
+                |keysigner| keysigner.pubkey == *pubkey
+            )
+        });
 
-
-        // Clone the iterator to avoid consuming it for the next map
-        if matched_signers.is_empty() {
+        if matched_signers.any(|signer| signer.is_none()) {
             warn!("Requested public key is not known!");
             warn!("Request: {:?}", request);
             warn!("Available Signers: {:?}", self.keysigners);
             return Err(Status::invalid_argument("I don't know the signer for one or more of the provided public keys."))
         }
 
-        let confirmed_signers = matched_signers.iter().map(|signer| signer.as_ref().unwrap());
+        let confirmed_signers = matched_signers.map(|signer| signer.unwrap());
 
         info!("Got Request that matches signers: {:?}", confirmed_signers);
 

--- a/src/dispatcher/server.rs
+++ b/src/dispatcher/server.rs
@@ -8,9 +8,7 @@ use async_std::sync::{Arc, Mutex};
 use clap::{App, Arg};
 use ed25519_zebra::{Signature, VerificationKey};
 use futures::{future, TryFutureExt};
-use futures::join;
 use itertools::Itertools;
-use log::LevelFilter;
 use simple_logger::SimpleLogger;
 use tokio::signal::unix::{signal, SignalKind};
 use tonic::{Request, Response, Status, transport::Server};
@@ -155,7 +153,7 @@ impl SignatureDispatcher for Ed25519SignatureDispatcher {
 
 #[tokio::main]
 async fn main() -> remote_signer::Result<()> {
-    SimpleLogger::from_env().with_level(LevelFilter::Info).init().unwrap();
+    SimpleLogger::from_env().init().unwrap();
     let config_arg = App::new("Remote Signer Dispatcher")
         .arg(Arg::with_name("config")
              .short("c")

--- a/src/dispatcher/server.rs
+++ b/src/dispatcher/server.rs
@@ -62,7 +62,8 @@ impl SignatureDispatcher for Ed25519SignatureDispatcher {
                 .find(|keysigner| keysigner.pubkey == *pubkey)
         });
 
-        if matched_signers.any(|signer| signer.is_none()) {
+        // Clone the iterator to avoid consuming it for the next map
+        if matched_signers.clone().any(|signer| signer.is_none()) {
             warn!("Requested public key is not known!");
             warn!("Request: {:?}", request);
             warn!("Available Signers: {:?}", self.keysigners);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ pub type Result<T> = std::result::Result<T, RemoteSignerError>;
 
 #[derive(DeriveError, Debug)]
 pub enum RemoteSignerError {
-    #[error("Something went wrong while the server was running. '{0}'" )]
+    #[error("Something went wrong while the server was running. '{0}'")]
     TonicError(#[from] tonic::transport::Error),
     #[error("Something went wrong while parsing configs. `{0}'")]
     Config(#[from] config::ConfigError),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,18 @@
 pub mod common;
+use thiserror::Error as DeriveError;
+
+pub type Result<T> = std::result::Result<T, RemoteSignerError>;
+
+#[derive(DeriveError, Debug)]
+pub enum RemoteSignerError {
+    #[error("Something went wrong while the server was running. '{0}'" )]
+    TonicError(#[from] tonic::transport::Error),
+    #[error("Something went wrong while parsing configs. `{0}'")]
+    Config(#[from] config::ConfigError),
+    #[error("Something went wrong with network address parsing. `{0}'")]
+    AddrParse(#[from] std::net::AddrParseError),
+    #[error("Something went wrong. '{0}'")]
+    Anyhow(#[from] anyhow::Error),
+    #[error("Something went wrong. '{0}'")]
+    Unknown(String),
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,5 @@ pub enum RemoteSignerError {
     #[error("Something went wrong with network address parsing. `{0}'")]
     AddrParse(#[from] std::net::AddrParseError),
     #[error("Something went wrong. '{0}'")]
-    Anyhow(#[from] anyhow::Error),
-    #[error("Something went wrong. '{0}'")]
     Unknown(String),
 }

--- a/src/signer/server.rs
+++ b/src/signer/server.rs
@@ -95,7 +95,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     info!("Serving on {}...", addr);
 
     Server::builder()
-        .tls_config(tls)?
+        // .tls_config(tls)?
         .add_service(SignerServer::new(signer))
         .serve(addr)
         .await?;

--- a/src/signer/server.rs
+++ b/src/signer/server.rs
@@ -85,6 +85,7 @@ async fn reload_configs_upon_signal(
     // Print whenever a HUP signal is received
     loop {
         stream.recv().await;
+        info!("sighup received");
         let conf = parse_confs(conf_path);
         if conf.is_err() {
             error!("Can't parse configs. {:?}", conf.err().unwrap());

--- a/src/signer/server.rs
+++ b/src/signer/server.rs
@@ -86,7 +86,7 @@ async fn main() -> remote_signer::Result<()> {
                 .takes_value(true)
                 .value_name("FILE")
                 .default_value("signer_config.json")
-                .help("Dispatcher .json configuration file"),
+                .help("Signer .json configuration file"),
         )
         .get_matches();
 

--- a/src/signer/server.rs
+++ b/src/signer/server.rs
@@ -1,7 +1,7 @@
 use std::convert::TryFrom;
 
 use tonic::{Request, Response, Status};
-use tonic::transport::{Server, ServerTlsConfig, Certificate, Identity};
+use tonic::transport::Server;
 
 use signer::signer_server::{Signer, SignerServer};
 use signer::{SignWithKeyRequest, SignWithKeyResponse};
@@ -14,6 +14,10 @@ use simple_logger::SimpleLogger;
 #[macro_use] extern crate log;
 
 use ed25519_zebra::SigningKey;
+use async_std::sync::{Arc, Mutex};
+use tokio::signal::unix::{SignalKind, signal};
+use remote_signer::common::config::{SignerConfig, BytesPubPriv};
+use async_std::net::SocketAddr;
 
 pub mod signer {
     tonic::include_proto!("signer");
@@ -21,8 +25,7 @@ pub mod signer {
 
 #[derive(Debug)]
 pub struct Ed25519Signer {
-    config: config::SignerConfig,
-    keypairs: Vec<config::BytesPubPriv>
+    keypairs: Arc<Mutex<Vec<config::BytesPubPriv>>>
 }
 
 #[tonic::async_trait]
@@ -35,14 +38,15 @@ impl Signer for Ed25519Signer {
         debug!("Got Request: {:?}", request);
 
         let r = request.get_ref();
-        let matched_key = match self.keypairs.iter().find(
+        let keys_guard = self.keypairs.lock().await;
+        let matched_key = match keys_guard.iter().find(
             |pair| pair.pubkey == r.pub_key
         ) {
             Some(key) => key,
             None => {
                 warn!("Requested public key is not known!");
                 warn!("Request: {:?}", request);
-                warn!("Available Pubkeys: {:?}", self.keypairs.iter().map(|pair| pair.pubkey.clone()).collect::<Vec<Vec<u8>>>());
+                warn!("Available Pubkeys: {:?}", keys_guard.iter().map(|pair| pair.pubkey.clone()).collect::<Vec<Vec<u8>>>());
                 return Err(Status::invalid_argument("This signer does not sign with the provided key."))
             }
         };
@@ -81,15 +85,44 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     debug!("Parsed configuration file: {:?}", config);
     let addr = config.bind_addr.parse()?;
 
-    let signer = Ed25519Signer { config, keypairs };
+    let signer = Ed25519Signer {
+        keypairs: Arc::new(Mutex::new(keypairs))
+    };
     debug!("Initialized Signer server: {:?}", signer);
 
     info!("Serving on {}...", addr);
+    let signal = reload_configs_upon_signal(conf_path, Arc::clone(&signer.keypairs));
 
-    Server::builder()
+    let serve = Server::builder()
         .add_service(SignerServer::new(signer))
-        .serve(addr)
-        .await?;
+        .serve(addr);
+
+
+    (serve.await?, signal.await?);
 
     Ok(())
+}
+
+async fn reload_configs_upon_signal(conf_path : &str, key_pairs: Arc<Mutex<Vec<BytesPubPriv>>>) -> Result<(), Box<dyn std::error::Error>> {
+    let mut stream = signal(SignalKind::hangup())?;
+
+    // Print whenever a HUP signal is received
+    loop {
+        stream.recv().await;
+        info!("got signal HUP");
+        let (_, keysigners, _) = parse_confs(conf_path).await?;
+        let mut signers = key_pairs.lock().await;
+        signers.clear();
+        for bk in keysigners {
+            signers.push(bk)
+        }
+    }
+}
+
+async fn parse_confs(conf_path: &str) -> Result<(SignerConfig, Vec<BytesPubPriv>, SocketAddr), Box<dyn std::error::Error>> {
+    info!("Parsing configuration file `{}`.", conf_path);
+    let (config, keysigners) = config::parse_signer(conf_path)?;
+    debug!("Parsed configuration file: {:?}", config);
+    let addr = config.bind_addr.parse()?;
+    Ok((config, keysigners, addr))
 }

--- a/src/signer/server.rs
+++ b/src/signer/server.rs
@@ -80,14 +80,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (config, keypairs) = config::parse_signer(conf_path)?;
     debug!("Parsed configuration file: {:?}", config);
     let addr = config.bind_addr.parse()?;
-    let server_cert = tokio::fs::read(&config.tls.cert).await?;
-    let server_key = tokio::fs::read(&config.tls.key).await?;
-    let server_identity = Identity::from_pem(server_cert, server_key);
-    let client_ca_cert = tokio::fs::read(&config.tls.ca).await?;
-    let client_ca_cert = Certificate::from_pem(client_ca_cert);
-    let tls = ServerTlsConfig::new()
-        .identity(server_identity)
-        .client_ca_root(client_ca_cert);
 
     let signer = Ed25519Signer { config, keypairs };
     debug!("Initialized Signer server: {:?}", signer);
@@ -95,7 +87,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     info!("Serving on {}...", addr);
 
     Server::builder()
-        // .tls_config(tls)?
         .add_service(SignerServer::new(signer))
         .serve(addr)
         .await?;

--- a/src/signer/server.rs
+++ b/src/signer/server.rs
@@ -136,9 +136,7 @@ async fn reload_configs_upon_signal(
         let (_, keysigners, _) = conf.unwrap();
         let mut signers = key_pairs.lock().await;
         signers.clear();
-        for signer in keysigners {
-            signers.push(signer);
-        }
+        signers.extend_from_slice(&keysigners);
     }
 }
 

--- a/src/signer/server.rs
+++ b/src/signer/server.rs
@@ -105,7 +105,7 @@ fn parse_confs(
     debug!("Parsed configuration file: {:?}", config);
     let addr = config
         .bind_addr
-        .parse()
+        .parse::<SocketAddr>()
         .map_err(|err| RemoteSignerError::from(err))?;
     Ok((config, keysigners, addr))
 }
@@ -129,7 +129,7 @@ async fn main() -> remote_signer::Result<()> {
     info!("Parsing configuration file `{}`.", conf_path);
     let (config, keypairs) = config::parse_signer(conf_path)?;
     debug!("Parsed configuration file: {:?}", config);
-    let addr = config.bind_addr.parse()?;
+    let addr = config.bind_addr.parse::<SocketAddr>()?;
 
     let signer = Ed25519Signer {
         keypairs: Arc::new(Mutex::new(keypairs)),

--- a/src/signer/server.rs
+++ b/src/signer/server.rs
@@ -94,7 +94,7 @@ async fn reload_configs_upon_signal(
         let mut signers = key_pairs.lock().await;
         signers.clear();
         signers.extend_from_slice(&keysigners);
-        info!("Configuration reloaded upon sighup")
+        info!("Configuration reloaded upon sighup");
     }
 }
 

--- a/src/signer/server.rs
+++ b/src/signer/server.rs
@@ -85,7 +85,6 @@ async fn reload_configs_upon_signal(
     // Print whenever a HUP signal is received
     loop {
         stream.recv().await;
-        info!("sighup received");
         let conf = parse_confs(conf_path);
         if conf.is_err() {
             error!("Can't parse configs. {:?}", conf.err().unwrap());
@@ -95,6 +94,7 @@ async fn reload_configs_upon_signal(
         let mut signers = key_pairs.lock().await;
         signers.clear();
         signers.extend_from_slice(&keysigners);
+        info!("Configuration reloaded upon sighup")
     }
 }
 

--- a/src/signer/server.rs
+++ b/src/signer/server.rs
@@ -119,7 +119,7 @@ async fn reload_configs_upon_signal(conf_path: &str, key_pairs: Arc<Mutex<Vec<By
     // Print whenever a HUP signal is received
     loop {
         stream.recv().await;
-        let conf = parse_confs(conf_path).await;
+        let conf = parse_confs(conf_path);
         if conf.is_err() {
             error!("Can't parse configs. {:?}", conf.err().unwrap());
             continue;
@@ -133,7 +133,7 @@ async fn reload_configs_upon_signal(conf_path: &str, key_pairs: Arc<Mutex<Vec<By
     }
 }
 
-async fn parse_confs(conf_path: &str) -> remote_signer::Result<(SignerConfig, Vec<BytesPubPriv>, SocketAddr)> {
+fn parse_confs(conf_path: &str) -> remote_signer::Result<(SignerConfig, Vec<BytesPubPriv>, SocketAddr)> {
     info!("Parsing configuration file `{}`.", conf_path);
     let (config, keysigners) = config::parse_signer(conf_path)?;
     debug!("Parsed configuration file: {:?}", config);

--- a/src/signer/server.rs
+++ b/src/signer/server.rs
@@ -93,7 +93,6 @@ async fn main() -> remote_signer::Result<()> {
     };
     debug!("Initialized Signer server: {:?}", signer);
 
-    info!("Serving on {}...", addr);
     let signal = reload_configs_upon_signal(conf_path, Arc::clone(&signer.keypairs));
 
     let serv = Server::builder()
@@ -101,7 +100,7 @@ async fn main() -> remote_signer::Result<()> {
         .serve(addr)
         .map_err(|error| RemoteSignerError::from(error));
 
-    info!("listening for sighup");
+    info!("Serving on {}...", addr);
 
     let result = future::try_join(signal, serv)
         .await;
@@ -113,6 +112,7 @@ async fn main() -> remote_signer::Result<()> {
 }
 
 async fn reload_configs_upon_signal(conf_path: &str, key_pairs: Arc<Mutex<Vec<BytesPubPriv>>>) -> remote_signer::Result<()> {
+    info!("listening for sighup");
     let mut stream = signal(SignalKind::hangup())
         .expect("Problems receiving signal");
 

--- a/src/signer/server.rs
+++ b/src/signer/server.rs
@@ -146,9 +146,7 @@ async fn main() -> remote_signer::Result<()> {
 
     info!("Serving on {}...", addr);
 
-    let result = future::try_join(signal, serv).await;
-
-    match result {
+    match future::try_join(signal, serv).await {
         Ok(_) => Ok(()),
         Err(e) => Err(e),
     }

--- a/src/signer/server.rs
+++ b/src/signer/server.rs
@@ -18,6 +18,7 @@ use async_std::sync::{Arc, Mutex};
 use tokio::signal::unix::{SignalKind, signal};
 use remote_signer::common::config::{SignerConfig, BytesPubPriv};
 use async_std::net::SocketAddr;
+use log::LevelFilter;
 
 pub mod signer {
     tonic::include_proto!("signer");
@@ -68,7 +69,7 @@ impl Signer for Ed25519Signer {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    SimpleLogger::from_env().init().unwrap();
+    SimpleLogger::from_env().with_level(LevelFilter::Info).init().unwrap();
     let config_arg = App::new("Remote Signer")
         .arg(Arg::with_name("config")
              .short("c")
@@ -97,6 +98,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .add_service(SignerServer::new(signer))
         .serve(addr);
 
+    info!("listening for sighup");
 
     (serve.await?, signal.await?);
 


### PR DESCRIPTION
### Description

Fixes #1

1. Removes TLS authentication
2. Reloads Dispatcher and Signer keys upon sighup
3. Implements custom error with `thiserror` crate

### Testing
Manually tested:
1. Working sighup
2. Expected errors

Will add automatic tests in later PR