### PR TITLE
changed for iota.go v3

### DIFF
--- a/docker/dispatcher/Dockerfile
+++ b/docker/dispatcher/Dockerfile
@@ -10,10 +10,9 @@ RUN cargo build --release --bin dispatcher-server
 ############################
 # Image
 ############################
-FROM gcr.io/distroless/base@sha256:5e0cc69445ed1d8a17198250a7249d56dd4b6966bb6b2118e60ae9194c310647
-COPY --from=build /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/
+FROM gcr.io/distroless/cc-debian11:nonroot
 
-COPY --from=build /src/target/release/dispatcher-server /
+COPY --chown=nonroot:nonroot --from=build /src/target/release/dispatcher-server /app/
 
-ENTRYPOINT ["/dispatcher-server"]
+ENTRYPOINT ["/app/dispatcher-server"]
 CMD ["--config=/config/dispatcher_config.json"]

--- a/docker/signer/Dockerfile
+++ b/docker/signer/Dockerfile
@@ -10,10 +10,9 @@ RUN cargo build --release --bin signer-server
 ############################
 # Image
 ############################
-FROM gcr.io/distroless/base@sha256:5e0cc69445ed1d8a17198250a7249d56dd4b6966bb6b2118e60ae9194c310647
-COPY --from=build /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/
+FROM gcr.io/distroless/cc-debian11:nonroot
 
-COPY --from=build /src/target/release/signer-server /
+COPY --chown=nonroot:nonroot --from=build /src/target/release/signer-server /app/
 
-ENTRYPOINT ["/signer-server"]
+ENTRYPOINT ["/app/signer-server"]
 CMD ["--config=/config/signer_config.json"]

--- a/proto/dispatcher/dispatcher.proto
+++ b/proto/dispatcher/dispatcher.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package dispatcher;
+package dispatcherv3;
 
 service SignatureDispatcher {
 

--- a/proto/signer/signer.proto
+++ b/proto/signer/signer.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package signer;
+package signerv3;
 
 service Signer {
 

--- a/src/dispatcher/client.rs
+++ b/src/dispatcher/client.rs
@@ -4,7 +4,7 @@ use dispatcher::SignMilestoneRequest;
 use hex::FromHex;
 
 pub mod dispatcher {
-    tonic::include_proto!("dispatcher");
+    tonic::include_proto!("dispatcherv3");
 }
 
 #[tokio::main]

--- a/src/dispatcher/server.rs
+++ b/src/dispatcher/server.rs
@@ -204,9 +204,22 @@ async fn reload_configs_upon_signal(
     }
 }
 
+async fn listen_to_sigterm() -> remote_signer::Result<()> {
+    info!("listening for sigterm");
+    
+    let mut stream = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()).unwrap();
+
+    // exit on SITGERM (for graceful docker shutdown)
+    loop {
+        stream.recv().await;
+        info!("got signal SIGTERM ... exit");
+        std::process::exit(1)
+    }
+}
+
 #[tokio::main]
 async fn main() -> remote_signer::Result<()> {
-    SimpleLogger::from_env().with_utc_timestamps().init().unwrap();
+    SimpleLogger::new().env().with_utc_timestamps().init().unwrap();
     let config_arg = App::new("Remote Signer Dispatcher")
         .arg(
             Arg::with_name("config")
@@ -234,9 +247,10 @@ async fn main() -> remote_signer::Result<()> {
         .map_err(|err| RemoteSignerError::from(err));
 
     let signal = reload_configs_upon_signal(&conf_path, key_signers);
+    let signal_sigterm = listen_to_sigterm();
 
     info!("Serving on {}...", addr);
-    match future::try_join(serv, signal).await {
+    match future::try_join3(serv, signal, signal_sigterm).await {
         Ok(_) => Ok(()),
         Err(e) => Err(e),
     }

--- a/src/dispatcher/server.rs
+++ b/src/dispatcher/server.rs
@@ -213,7 +213,7 @@ async fn listen_to_sigterm() -> remote_signer::Result<()> {
     loop {
         stream.recv().await;
         info!("got signal SIGTERM ... exit");
-        std::process::exit(1)
+        std::process::exit(0)
     }
 }
 

--- a/src/dispatcher/server.rs
+++ b/src/dispatcher/server.rs
@@ -24,11 +24,11 @@ use signer::signer_client::SignerClient;
 use signer::SignWithKeyRequest;
 
 pub mod dispatcher {
-    tonic::include_proto!("dispatcher");
+    tonic::include_proto!("dispatcherv3");
 }
 
 pub mod signer {
-    tonic::include_proto!("signer");
+    tonic::include_proto!("signerv3");
 }
 
 #[derive(Debug)]
@@ -206,7 +206,7 @@ async fn reload_configs_upon_signal(
 
 #[tokio::main]
 async fn main() -> remote_signer::Result<()> {
-    SimpleLogger::from_env().init().unwrap();
+    SimpleLogger::from_env().with_utc_timestamps().init().unwrap();
     let config_arg = App::new("Remote Signer Dispatcher")
         .arg(
             Arg::with_name("config")

--- a/src/signer/server.rs
+++ b/src/signer/server.rs
@@ -107,7 +107,7 @@ async fn listen_to_sigterm() -> remote_signer::Result<()> {
     loop {
         stream.recv().await;
         info!("got signal SIGTERM ... exit");
-        std::process::exit(1)
+        std::process::exit(0)
     }
 }
 

--- a/src/signer/server.rs
+++ b/src/signer/server.rs
@@ -98,6 +98,19 @@ async fn reload_configs_upon_signal(
     }
 }
 
+async fn listen_to_sigterm() -> remote_signer::Result<()> {
+    info!("listening for sigterm");
+    
+    let mut stream = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()).unwrap();
+
+    // exit on SITGERM (for graceful docker shutdown)
+    loop {
+        stream.recv().await;
+        info!("got signal SIGTERM ... exit");
+        std::process::exit(1)
+    }
+}
+
 fn parse_confs(
     conf_path: &str,
 ) -> remote_signer::Result<(SignerConfig, Vec<BytesPubPriv>, SocketAddr)> {
@@ -113,7 +126,7 @@ fn parse_confs(
 
 #[tokio::main]
 async fn main() -> remote_signer::Result<()> {
-    SimpleLogger::from_env().with_utc_timestamps().init().unwrap();
+    SimpleLogger::new().env().with_utc_timestamps().init().unwrap();
     let config_arg = App::new("Remote Signer")
         .arg(
             Arg::with_name("config")
@@ -138,6 +151,7 @@ async fn main() -> remote_signer::Result<()> {
     debug!("Initialized Signer server: {:?}", signer);
 
     let signal = reload_configs_upon_signal(conf_path, Arc::clone(&signer.keypairs));
+    let signal_sigterm = listen_to_sigterm();
 
     let serv = Server::builder()
         .add_service(SignerServer::new(signer))
@@ -146,7 +160,7 @@ async fn main() -> remote_signer::Result<()> {
 
     info!("Serving on {}...", addr);
 
-    match future::try_join(signal, serv).await {
+    match future::try_join3(signal, serv, signal_sigterm).await {
         Ok(_) => Ok(()),
         Err(e) => Err(e),
     }

--- a/src/signer/server.rs
+++ b/src/signer/server.rs
@@ -24,7 +24,7 @@ use remote_signer::RemoteSignerError;
 use tokio::signal::unix::{signal, SignalKind};
 
 pub mod signer {
-    tonic::include_proto!("signer");
+    tonic::include_proto!("signerv3");
 }
 
 #[derive(Debug)]
@@ -113,7 +113,7 @@ fn parse_confs(
 
 #[tokio::main]
 async fn main() -> remote_signer::Result<()> {
-    SimpleLogger::from_env().init().unwrap();
+    SimpleLogger::from_env().with_utc_timestamps().init().unwrap();
     let config_arg = App::new("Remote Signer")
         .arg(
             Arg::with_name("config")


### PR DESCRIPTION
updates for iota.go v3 (needed for stardust networks)

- protobuf-packages renamed (appended `v3`)
- docker image changed to distroless debian11 nonroot (fixes GLIBC-problem)
- added SIGTERM handler for graceful docker shutdown

